### PR TITLE
Reading data from small municipalities

### DIFF
--- a/R/read11.R
+++ b/R/read11.R
@@ -1,0 +1,51 @@
+#' @title Reads the basic data files for municipalities of 250 inhabitants or less
+#'
+#' @param file Path to the .DAT file that begins with 05.
+#'
+#'  @return data.frame
+#'
+#' @importFrom utils download.file
+#' @importFrom utils unzip
+#'
+#' @keywords internal
+#'
+read11 <- function(file, tempd) {
+  ### Leo los ficheros DAT necesarios
+  con <- file(file.path(tempd, file), encoding = "ISO-8859-1")
+  df <- data.frame( value = readLines(con) )
+  close(con)
+
+  ### Separo los valores según el diseño de registro
+  lineas <- df$value
+
+  df$tipo_eleccion <- "04"
+  df$anno <- substr(lineas, 3, 6)
+  df$mes <- substr(lineas, 7, 8)
+  df$vuelta <- substr(lineas, 9, 9)
+  df$codigo_ccaa <- substr(lineas, 10, 11)
+  df$codigo_provincia <- substr(lineas, 12, 13)
+  df$codigo_municipio <- substr(lineas, 14, 16)
+  df$codigo_distrito <- "99"
+  # df$codigo_distrito_electoral <- NA
+  df$codigo_partido_judicial <- substr(lineas, 117, 119)
+  df$codigo_diputacion <- substr(lineas, 120, 122)
+  df$codigo_comarca <- substr(lineas, 123, 125)
+  df$poblacion_derecho <- as.numeric(substr(lineas, 126, 128))
+  df$numero_mesas <- as.numeric(substr(lineas, 129, 130))
+  df$censo_ine <- as.numeric(substr(lineas, 131, 133))
+  df$censo_escrutinio <- as.numeric(substr(lineas, 134, 136))
+  df$censo_cere <- as.numeric(substr(lineas, 137, 139))
+  df$votantes_cere <- as.numeric(substr(lineas, 140, 142))
+  df$participacion_1 <- as.numeric(substr(lineas, 143, 145))
+  df$participacion_2 <- as.numeric(substr(lineas, 146, 148))
+  df$votos_blancos <- as.numeric(substr(lineas, 149, 151))
+  df$votos_nulos <- as.numeric(substr(lineas, 152, 154))
+  df$votos_candidaturas <- as.numeric(substr(lineas, 155, 157))
+  df$numero_concejales <- as.numeric(substr(lineas, 158, 159))
+  df$datos_oficiales <- substr(lineas, 160, 160)
+
+  df <- df[,-1]
+
+  return(df)
+
+}

--- a/R/read11.R
+++ b/R/read11.R
@@ -1,6 +1,6 @@
 #' @title Reads the basic data files for municipalities of 250 inhabitants or less
 #'
-#' @param file Path to the .DAT file that begins with 05.
+#' @param file Path to the .DAT file that begins with 11.
 #'
 #'  @return data.frame
 #'

--- a/R/read12.R
+++ b/R/read12.R
@@ -1,0 +1,43 @@
+#' @title Reads the candidacy files for small municipalities
+#'
+#' @param file Path to the .DAT file that begins with 03.
+#'
+#' @return data.frame
+#'
+#' @importFrom utils download.file
+#' @importFrom utils unzip
+#'
+#' @keywords internal
+#'
+read12 <- function(file, tempd) {
+  ### Leo los ficheros DAT necesarios
+  con <- file(file.path(tempd, file), encoding = "ISO-8859-1")
+  df <- data.frame( value = readLines(con) )
+  close(con)
+
+  ### Separo los valores según el diseño de registro
+  lineas <- df$value
+
+  df$tipo_eleccion <- "04"
+  df$anno <- substr(lineas, 3, 6)
+  df$mes <- substr(lineas, 7, 8)
+  df$vuelta <- substr(lineas, 9, 9)
+  df$codigo_provincia <- substr(lineas, 10, 11)
+  df$codigo_municipio <- substr(lineas, 12, 14)
+  df$codigo_distrito <- "99"
+  df$codigo_partido <- as.character(substr(lineas, 15, 20))
+  df$votos <- as.numeric(substr(lineas, 21, 23))
+  df$concejales_obtenidos <- as.numeric(substr(lineas, 24, 25))
+
+  df <- df[ , -1]
+  df <- unique(df) # individual candidates
+
+  # Check if different candidaturas got different votes
+  if(nrow(df) != nrow(unique(df[,
+    c("codigo_provincia", "codigo_municipio", "codigo_partido")]))){
+      stop("In small municipalities: different candidates from same party got different votes (?)")
+  }
+
+  return(df)
+
+}

--- a/R/read12.R
+++ b/R/read12.R
@@ -1,6 +1,6 @@
 #' @title Reads the candidacy files for small municipalities
 #'
-#' @param file Path to the .DAT file that begins with 03.
+#' @param file Path to the .DAT file that begins with 12.
 #'
 #' @return data.frame
 #'


### PR DESCRIPTION
Fixing issue #8. Modified `muni.R` so it also reads data from municipalities below 250 inhabitants, which are kept in separate files. The function now reads those two extra files when `tipo_eleccion = "municipales"` and bind its rows to the master data frame. 

Two new files have been added with functions that read the lines from those DAT files (`read11.R` and `read12.R`). The follow the structure from the other similar functions already existing. When some fields are missing (tipo de elección y distrito), they add them manually (`"04"` for tipo de elección, and `"99"` for distrito, as these are all municipal-level results).

In addition, `read12()` includes a stop function in case two candidates from the same political party receive different votes, which would be problematic for the way the file is read and cleaned. (In these small-municipality data files, results are given for each candidate individually.)