### PR TITLE
Use siane version to avoid potential issues

### DIFF
--- a/vignettes/municipios.Rmd
+++ b/vignettes/municipios.Rmd
@@ -37,8 +37,8 @@ Import the geometry shapes for the municipalities using [mapSpain](https://githu
 
 ```{r}
 library(mapSpain)
-shp <- esp_get_munic(year = "2016") %>% select(LAU_CODE)
-shp_ccaa <- mapSpain::esp_get_ccaa()
+shp <- esp_get_munic_siane(year = "2016") %>% select(LAU_CODE)
+shp_ccaa <- mapSpain::esp_get_ccaa_siane()
 ```
 
 


### PR DESCRIPTION
Hola @hmeleiro:

He visto que en la viñeta de **infoelectoral** usas **mapSpain** para extraer los polígonos de los municipios a una fecha dada.

El riesgo es veo es que al usar `year = "2016"` se fuerza una descarga a través de **giscoR**. Esta descarga es bastante pesada (>100Mb) porque tiene todos los municipios de la UE (**mapSpain** luego filtra solo los de España) y además en el pasado ha habido problemas con el acceso a GISCO por cambios en el servidor de la API (https://github.com/rOpenGov/giscoR/issues/74, https://github.com/rOpenGov/giscoR/issues/69 y varios más).

Al incluirla en la viñeta, que CRAN ejecuta regularmente, veo cierto riesgo de que en un momento dado la viñeta dé problemas y tengas algún email de aviso desde CRAN por ERROR. 

Este PR cambia `esp_get_munic()` por `esp_get_munic_siane()`, que descarga la información equivalente pero proporcionada por el IGN solo para España, y es mucho más ligera (5Mb). Los resultados son los mismos y esta función jamás me ha dado problemas.

Saludos.